### PR TITLE
Reset mail options fix.

### DIFF
--- a/Services/WebServices/ECS/classes/class.ilAuthProviderECS.php
+++ b/Services/WebServices/ECS/classes/class.ilAuthProviderECS.php
@@ -384,9 +384,23 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
 	 */
 	protected function resetMailOptions($a_usr_id)
 	{
+		global $rbacsystem;
+
 		include_once './Services/Mail/classes/class.ilMailOptions.php';
+		include_once './Services/Mail/classes/class.ilMailGlobalServices.php';
+
+		$mail_ref_id = ilMailGlobalServices::getMailObjectRefId();
+		if($rbacsystem->checkAccessOfUser($a_usr_id, 'smtp_mail', $mail_ref_id))
+		{
+			$mail_type = ilMailOptions::INCOMING_BOTH
+		}
+		else
+		{
+			$mail_type = ilMailOptions::INCOMING_LOCAL;
+		}
+
 		$options = new ilMailOptions($a_usr_id);
-		$options->setIncomingType(ilMailOptions::INCOMING_LOCAL);
+		$options->setIncomingType($mail_type);
 		$options->updateOptions();
 	}
 }


### PR DESCRIPTION
Für ECS-Benutzer, die das "smtp_mail"-Recht an Adminsitration -> Mail besitzen, wird der Mail-Empfangstyp auf lokal und Weiterleitung gesetzt.
Alle anderen erhalten Mails nur als "ILIAS interne Mail".